### PR TITLE
Bugfix: Trailing whitespace after comma.

### DIFF
--- a/lib/src/http_auth_utils.dart
+++ b/lib/src/http_auth_utils.dart
@@ -17,7 +17,7 @@ Map<String, String> splitAuthenticateHeader(String header) {
 
   var ret = new Map<String, String>();
 
-  final components = header.split(', ');
+  final components = header.split(',').map((token) => token.trim());
   for (var component in components) {
     final kv = component.split('=');
     ret[kv[0]] = kv.getRange(1, kv.length).join('=').replaceAll('"', '');


### PR DESCRIPTION
For servers responding with Authorization header without trailing whitespace after each comma, the following edit will allow for correct parsing of those.