### PR TITLE
Add close method to NegotiateAuthClient

### DIFF
--- a/lib/src/http_auth_negotiate.dart
+++ b/lib/src/http_auth_negotiate.dart
@@ -44,4 +44,10 @@ class NegotiateAuthClient extends http.BaseClient {
 
     return response;
   }
+
+  @override
+  void close() {
+    _inner.close();
+    _authClient?.close();
+  }
 }


### PR DESCRIPTION
Implement missing close() method to NegotiateAuthClient.