### PR TITLE
Remove quotes from algorithm, qop, and nc

### DIFF
--- a/lib/src/http_auth_utils.dart
+++ b/lib/src/http_auth_utils.dart
@@ -216,7 +216,13 @@ class DigestAuth {
         _opaque, _realm!, cnonce, _nonce, _nc, username, password);
     final authValuesString = authValues.entries
         .where((e) => e.value != null)
-        .map((e) => [e.key, '="', e.value, '"'].join(''))
+        .map((e) => [
+          e.key, 
+          '=', 
+          ['algorithm', 'qop', 'nc'].contains(e.key) ? '' : '"', 
+          e.value, 
+          ['algorithm', 'qop', 'nc'].contains(e.key) ? '' : '"'
+        ].join(''))
         .toList()
         .join(', ');
     final authString = 'Digest $authValuesString';


### PR DESCRIPTION
As stated in [RFC7616](https://www.rfc-editor.org/rfc/rfc7616#section-3.4), `algorithm`, `qop`, and `nc` are not _historically_ quoted.
Quoting those fields can lead to unauthorized response, even if the values present in them is correct.

This is potentially related to #12 and #13 